### PR TITLE
Add Maintenance Disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Safe{Core} Protocol Specification
+**:warning: This repository is not actively developed at the moment. :warning:**
 
+# Safe{Core} Protocol Specification
 
 See also:
 - [Protocol Whitepaper](./whitepaper.pdf)


### PR DESCRIPTION
This PR adds a disclaimer to the README that the repository is no longer being actively developed at the moment by the protocol team, although we expect to resume development some time in the near future.